### PR TITLE
October 2018 update, post-PLAsTiCC launch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ install:
 
 # command to run tests
 script:
-    make -C test
-    make -C test html
+  - make -C test
+  - make -C test html

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ install:
 #  - python setup.py install
 
 # command to run tests
-script: 
+script:
+    make -C test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+# Based on the mkauthlist travis set-up at https://github.com/DarkEnergySurvey/mkauthlist/blob/master/.travis.yml
+
+os:
+  - linux
+
+language: python
+python:
+  - "3.6"
+
+notifications:
+  email: false
+
+sudo: required
+
+# To get latex and revtex4-1
+before_install:
+  - yes "" | sudo add-apt-repository ppa:jonathonf/texlive
+  - sudo apt-get update -y
+  - sudo apt-get install -y --no-install-recommends
+     texlive-fonts-recommended
+     texlive-latex-extra
+     texlive-latex-recommended
+     texlive-publishers
+     texlive-generic-recommended
+     latex-xcolor
+
+# Setup python dependencies and install package
+install:
+#  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+#  - bash miniconda.sh -b -p $HOME/miniconda
+#  - export PATH="$HOME/miniconda/bin:$PATH"
+#  - conda config --set always_yes yes --set changeps1 no
+#  - conda info -a
+#  - conda create -q -n travis-env python=$TRAVIS_PYTHON_VERSION numpy nose -c conda-forge
+#  - source activate travis-env
+#  - python setup.py install
+
+# command to run tests
+script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ before_install:
   - sudo apt-get install -y --no-install-recommends
      texlive-fonts-recommended
      texlive-latex-extra
+     texlive-bibtex-extra
      texlive-latex-recommended
      texlive-publishers
      texlive-generic-recommended

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,17 @@ before_install:
 
 # Setup python dependencies and install package
 install:
-#  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-#  - bash miniconda.sh -b -p $HOME/miniconda
-#  - export PATH="$HOME/miniconda/bin:$PATH"
-#  - conda config --set always_yes yes --set changeps1 no
-#  - conda info -a
-#  - conda create -q -n travis-env python=$TRAVIS_PYTHON_VERSION numpy nose -c conda-forge
-#  - source activate travis-env
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda info -a
+  - conda create -q -n travis-env python=$TRAVIS_PYTHON_VERSION numpy nose -c conda-forge
+  - source activate travis-env
 #  - python setup.py install
+  - pip install -r requirements.txt
 
 # command to run tests
 script:
     make -C test
+    make -C test html

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, 2017, 2018, Adam Mantz, Alex Drlica-Wagner, Phil Marshall (LSST Dark Energy Science Collaboration)
+Copyright (c) 2016, Adam Mantz, Alex Drlica-Wagner, Phil Marshall (LSST Dark Energy Science Collaboration)
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/bib/lsstdesc.bib
+++ b/bib/lsstdesc.bib
@@ -1,17 +1,17 @@
 % lsstdesc.bib
-% !! DO NOT EDIT! !!
+% !! DO NOT EDIT, EXCEPT BY PULL REQUEST !!
 % This file is maintained by the LSST DESC pub board, semi-automatically, and contains all citeable LSST DESC papers.
 
 % LSST DESC journal papers:
 
 @ARTICLE{Mao1709.09665,
-   author = {{Mao}, Y.-Y. and {Kovacs}, E. and {Heitmann}, K. and {Uram}, T.~D. and 
-	{Benson}, A.~J. and {Campbell}, D. and {Cora}, S.~A. and {DeRose}, J. and 
-	{Di Matteo}, T. and {Habib}, S. and {Hearin}, A.~P. and {Bryce Kalmbach}, J. and 
-	{Krughoff}, K.~S. and {Lanusse}, F. and {Luki{\'c}}, Z. and 
-	{Mandelbaum}, R. and {Newman}, J.~A. and {Padilla}, N. and {Paillas}, E. and 
-	{Pope}, A. and {Ricker}, P.~M. and {Ruiz}, A.~N. and {Tenneti}, A. and 
-	{Vega-Mart{\'{\i}}nez}, C.~A. and {Wechsler}, R.~H. and {Zhou}, R. and 
+   author = {{Mao}, Y.-Y. and {Kovacs}, E. and {Heitmann}, K. and {Uram}, T.~D. and
+	{Benson}, A.~J. and {Campbell}, D. and {Cora}, S.~A. and {DeRose}, J. and
+	{Di Matteo}, T. and {Habib}, S. and {Hearin}, A.~P. and {Bryce Kalmbach}, J. and
+	{Krughoff}, K.~S. and {Lanusse}, F. and {Luki{\'c}}, Z. and
+	{Mandelbaum}, R. and {Newman}, J.~A. and {Padilla}, N. and {Paillas}, E. and
+	{Pope}, A. and {Ricker}, P.~M. and {Ruiz}, A.~N. and {Tenneti}, A. and
+	{Vega-Mart{\'{\i}}nez}, C.~A. and {Wechsler}, R.~H. and {Zhou}, R. and
 	{Zu}, Y. and {The LSST Dark Energy Science Collaboration}},
     title = "{DESCQA: An Automated Validation Framework for Synthetic Sky Catalogs}",
   journal = {\apjs},
@@ -43,7 +43,7 @@ archivePrefix = "arXiv",
 }
 
 @ARTICLE{Malz1806.00014,
-   author = {{Malz}, A.~I. and {Marshall}, P.~J. and {DeRose}, J. and {Graham}, M.~L. and 
+   author = {{Malz}, A.~I. and {Marshall}, P.~J. and {DeRose}, J. and {Graham}, M.~L. and
 	{Schmidt}, S.~J. and {Wechsler}, R. and {(LSST Dark Energy Science Collaboration}
 	},
     title = "{Approximating Photo-z PDFs for Large Surveys}",
@@ -76,12 +76,12 @@ archivePrefix = "arXiv",
 }
 
 @ARTICLE{Malz1809.11145,
-   author = {{Malz}, A. and {Hlo{\v z}ek}, R. and {Allam}, Jr, T. and {Bahmanyar}, A. and 
-	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Ishida}, E. and 
-	{Jha}, S. and {Jones}, D. and {Kessler}, R. and {Lochner}, M. and 
-	{Mahabal}, A. and {Mandel}, K. and {Mart{\'{\i}}nez-Galarza}, R. and 
-	{McEwen}, J. and {Muthukrishna}, D. and {Narayan}, G. and {Peiris}, H. and 
-	{Peters}, C. and {Setzer}, C. and {The LSST Dark Energy Science Collaboration} and 
+   author = {{Malz}, A. and {Hlo{\v z}ek}, R. and {Allam}, Jr, T. and {Bahmanyar}, A. and
+	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Ishida}, E. and
+	{Jha}, S. and {Jones}, D. and {Kessler}, R. and {Lochner}, M. and
+	{Mahabal}, A. and {Mandel}, K. and {Mart{\'{\i}}nez-Galarza}, R. and
+	{McEwen}, J. and {Muthukrishna}, D. and {Narayan}, G. and {Peiris}, H. and
+	{Peters}, C. and {Setzer}, C. and {The LSST Dark Energy Science Collaboration} and
 	{LSST Transients}, T. and {Variable Stars Science Collaboration}
 	},
     title = "{The Photometric LSST Astronomical Time-series Classification Challenge (PLAsTiCC): Selection of a performance metric for classification probabilities balancing diverse science goals}",
@@ -115,15 +115,15 @@ collaboration = {LSST Dark Energy Science}
 }
 
 @ARTICLE{v1DESC-SRD,
-   author = {{LSST DESC} and {Mandelbaum}, R. and 
-	{Eifler}, T. and {Hlo{\v z}ek}, R. and {Collett}, T. and {Gawiser}, E. and 
-	{Scolnic}, D. and {Alonso}, D. and {Awan}, H. and {Biswas}, R. and 
-	{Blazek}, J. and {Burchat}, P. and {Chisari}, N.~E. and {Dell'Antonio}, I. and 
-	{Digel}, S. and {Frieman}, J. and {Goldstein}, D.~A. and {Hook}, I. and 
-	{Ivezi{\'c}}, {\v Z}. and {Kahn}, S.~M. and {Kamath}, S. and 
-	{Kirkby}, D. and {Kitching}, T. and {Krause}, E. and {Leget}, P.-F. and 
-	{Marshall}, P.~J. and {Meyers}, J. and {Miyatake}, H. and {Newman}, J.~A. and 
-	{Nichol}, R. and {Rykoff}, E. and {Sanchez}, F.~J. and {Slosar}, A. and 
+   author = {{LSST DESC} and {Mandelbaum}, R. and
+	{Eifler}, T. and {Hlo{\v z}ek}, R. and {Collett}, T. and {Gawiser}, E. and
+	{Scolnic}, D. and {Alonso}, D. and {Awan}, H. and {Biswas}, R. and
+	{Blazek}, J. and {Burchat}, P. and {Chisari}, N.~E. and {Dell'Antonio}, I. and
+	{Digel}, S. and {Frieman}, J. and {Goldstein}, D.~A. and {Hook}, I. and
+	{Ivezi{\'c}}, {\v Z}. and {Kahn}, S.~M. and {Kamath}, S. and
+	{Kirkby}, D. and {Kitching}, T. and {Krause}, E. and {Leget}, P.-F. and
+	{Marshall}, P.~J. and {Meyers}, J. and {Miyatake}, H. and {Newman}, J.~A. and
+	{Nichol}, R. and {Rykoff}, E. and {Sanchez}, F.~J. and {Slosar}, A. and
 	{Sullivan}, M. and {Troxel}, M.~A.},
     title = "{The LSST DESC Science Requirements Document v1}",
   journal = {ArXiv e-prints},
@@ -137,13 +137,13 @@ archivePrefix = "arXiv",
 }
 
 @ARTICLE{PLAsTiCC1810.00001,
-   author = {{The PLAsTiCC team} and {Allam}, Jr., T. and {Bahmanyar}, A. and 
-	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Hlo{\v z}ek}, R. and 
-	{Ishida}, E.~E.~O. and {Jha}, S.~W. and {Jones}, D.~O. and {Kessler}, R. and 
-	{Lochner}, M. and {Mahabal}, A.~A. and {Malz}, A.~I. and {Mandel}, K.~S. and 
-	{Mart{\'{\i}}nez-Galarza}, J.~R. and {McEwen}, J.~D. and {Muthukrishna}, D. and 
-	{Narayan}, G. and {Peiris}, H. and {Peters}, C.~M. and {Ponder}, K. and 
-	{Setzer}, C.~N. and {The LSST Dark Energy Science Collaboration} and 
+   author = {{The PLAsTiCC team} and {Allam}, Jr., T. and {Bahmanyar}, A. and
+	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Hlo{\v z}ek}, R. and
+	{Ishida}, E.~E.~O. and {Jha}, S.~W. and {Jones}, D.~O. and {Kessler}, R. and
+	{Lochner}, M. and {Mahabal}, A.~A. and {Malz}, A.~I. and {Mandel}, K.~S. and
+	{Mart{\'{\i}}nez-Galarza}, J.~R. and {McEwen}, J.~D. and {Muthukrishna}, D. and
+	{Narayan}, G. and {Peiris}, H. and {Peters}, C.~M. and {Ponder}, K. and
+	{Setzer}, C.~N. and {The LSST Dark Energy Science Collaboration} and
 	{LSST Transients}, T. and {Variable Stars Science Collaboration}
 	},
     title = "{The Photometric LSST Astronomical Time-series Classification Challenge (PLAsTiCC): Data set}",
@@ -157,4 +157,3 @@ archivePrefix = "arXiv",
    adsurl = {http://adsabs.harvard.edu/abs/2018arXiv181000001T},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-

--- a/bib/lsstdesc.bib
+++ b/bib/lsstdesc.bib
@@ -1,8 +1,8 @@
 % lsstdesc.bib
 % !! DO NOT EDIT! !!
-% This file is maintained by the LSST DESC pub board, semi-automatically.
+% This file is maintained by the LSST DESC pub board, semi-automatically, and contains all citeable LSST DESC papers.
 
-% LSST DESC papers:
+% LSST DESC journal papers:
 
 @ARTICLE{Mao1709.09665,
    author = {{Mao}, Y.-Y. and {Kovacs}, E. and {Heitmann}, K. and {Uram}, T.~D. and 
@@ -42,8 +42,62 @@ archivePrefix = "arXiv",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
+@ARTICLE{Malz1806.00014,
+   author = {{Malz}, A.~I. and {Marshall}, P.~J. and {DeRose}, J. and {Graham}, M.~L. and 
+	{Schmidt}, S.~J. and {Wechsler}, R. and {(LSST Dark Energy Science Collaboration}
+	},
+    title = "{Approximating Photo-z PDFs for Large Surveys}",
+  journal = {\aj},
+archivePrefix = "arXiv",
+   eprint = {1806.00014},
+ primaryClass = "astro-ph.IM",
+ keywords = {astronomical databases: miscellaneous, catalogs, galaxies: distances and redshifts, methods: miscellaneous, methods: statistical },
+     year = 2018,
+    month = jul,
+   volume = 156,
+      eid = {35},
+    pages = {35},
+      doi = {10.3847/1538-3881/aac6b5},
+   adsurl = {http://adsabs.harvard.edu/abs/2018AJ....156...35M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
 
-% Useful LSST / DESC references:
+@ARTICLE{Yao1809.07273,
+   author = {{Yao}, J. and {Ishak}, M. and {Troxel}, M.~A.},
+    title = "{Self-calibration method for II and GI types of intrinsic alignments of galaxies}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1809.07273},
+ keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
+     year = 2018,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180907273Y},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+@ARTICLE{Malz1809.11145,
+   author = {{Malz}, A. and {Hlo{\v z}ek}, R. and {Allam}, Jr, T. and {Bahmanyar}, A. and 
+	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Ishida}, E. and 
+	{Jha}, S. and {Jones}, D. and {Kessler}, R. and {Lochner}, M. and 
+	{Mahabal}, A. and {Mandel}, K. and {Mart{\'{\i}}nez-Galarza}, R. and 
+	{McEwen}, J. and {Muthukrishna}, D. and {Narayan}, G. and {Peiris}, H. and 
+	{Peters}, C. and {Setzer}, C. and {The LSST Dark Energy Science Collaboration} and 
+	{LSST Transients}, T. and {Variable Stars Science Collaboration}
+	},
+    title = "{The Photometric LSST Astronomical Time-series Classification Challenge (PLAsTiCC): Selection of a performance metric for classification probabilities balancing diverse science goals}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1809.11145},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2018,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180911145M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+% LSST DESC notes and white papers:
 
 @ARTICLE{WhitePaper,
    author = {{LSST Dark Energy Science Collaboration}},
@@ -60,32 +114,47 @@ archivePrefix = "arXiv",
 collaboration = {LSST Dark Energy Science}
 }
 
-@ARTICLE{ScienceBook,
-   author = {{LSST Science Collaboration}},
-    title = "{LSST Science Book, Version 2.0}",
+@ARTICLE{v1DESC-SRD,
+   author = {{LSST DESC} and {Mandelbaum}, R. and 
+	{Eifler}, T. and {Hlo{\v z}ek}, R. and {Collett}, T. and {Gawiser}, E. and 
+	{Scolnic}, D. and {Alonso}, D. and {Awan}, H. and {Biswas}, R. and 
+	{Blazek}, J. and {Burchat}, P. and {Chisari}, N.~E. and {Dell'Antonio}, I. and 
+	{Digel}, S. and {Frieman}, J. and {Goldstein}, D.~A. and {Hook}, I. and 
+	{Ivezi{\'c}}, {\v Z}. and {Kahn}, S.~M. and {Kamath}, S. and 
+	{Kirkby}, D. and {Kitching}, T. and {Krause}, E. and {Leget}, P.-F. and 
+	{Marshall}, P.~J. and {Meyers}, J. and {Miyatake}, H. and {Newman}, J.~A. and 
+	{Nichol}, R. and {Rykoff}, E. and {Sanchez}, F.~J. and {Slosar}, A. and 
+	{Sullivan}, M. and {Troxel}, M.~A.},
+    title = "{The LSST DESC Science Requirements Document v1}",
   journal = {ArXiv e-prints},
 archivePrefix = "arXiv",
-   eprint = {0912.0201},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Extragalactic Astrophysics, Astrophysics - Earth and Planetary Astrophysics, Astrophysics - Galaxy Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
-     year = 2009,
-    month = dec,
-   adsurl = {http://adsabs.harvard.edu/abs/2009arXiv0912.0201L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System},
-collaboration = {LSST Science}
+   eprint = {1809.01669v1},
+ keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+     year = 2018,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180901669T},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{Overview,
-   author = {{Ivezic}, Z. and {Tyson}, J.~A. and others},
-    title = "{LSST: from Science Drivers to Reference Design and Anticipated Data Products}",
+@ARTICLE{PLAsTiCC1810.00001,
+   author = {{The PLAsTiCC team} and {Allam}, Jr., T. and {Bahmanyar}, A. and 
+	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Hlo{\v z}ek}, R. and 
+	{Ishida}, E.~E.~O. and {Jha}, S.~W. and {Jones}, D.~O. and {Kessler}, R. and 
+	{Lochner}, M. and {Mahabal}, A.~A. and {Malz}, A.~I. and {Mandel}, K.~S. and 
+	{Mart{\'{\i}}nez-Galarza}, J.~R. and {McEwen}, J.~D. and {Muthukrishna}, D. and 
+	{Narayan}, G. and {Peiris}, H. and {Peters}, C.~M. and {Ponder}, K. and 
+	{Setzer}, C.~N. and {The LSST Dark Energy Science Collaboration} and 
+	{LSST Transients}, T. and {Variable Stars Science Collaboration}
+	},
+    title = "{The Photometric LSST Astronomical Time-series Classification Challenge (PLAsTiCC): Data set}",
   journal = {ArXiv e-prints},
 archivePrefix = "arXiv",
-   eprint = {0805.2366},
- keywords = {Astrophysics},
-     year = 2008,
-    month = may,
-   adsurl = {http://adsabs.harvard.edu/abs/2008arXiv0805.2366I},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System},
-collaboration = {LSST}
+   eprint = {1810.00001},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2018,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv181000001T},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
-%{% endraw %}
+

--- a/bib/lsstdesc.bib
+++ b/bib/lsstdesc.bib
@@ -1,8 +1,126 @@
 % lsstdesc.bib
 % !! DO NOT EDIT, EXCEPT BY PULL REQUEST !!
-% This file is maintained by the LSST DESC pub board, semi-automatically, and contains all citeable LSST DESC papers.
+% This file is maintained by the LSST DESC pub board,
+% semi-automatically, and contains all citeable LSST DESC papers
+% and Notes, most recent first.
 
-% LSST DESC journal papers:
+
+@ARTICLE{PLAsTiCC1810.00001,
+   author = {{The PLAsTiCC team} and {Allam}, Jr., T. and {Bahmanyar}, A. and
+	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Hlo{\v z}ek}, R. and
+	{Ishida}, E.~E.~O. and {Jha}, S.~W. and {Jones}, D.~O. and {Kessler}, R. and
+	{Lochner}, M. and {Mahabal}, A.~A. and {Malz}, A.~I. and {Mandel}, K.~S. and
+	{Mart{\'{\i}}nez-Galarza}, J.~R. and {McEwen}, J.~D. and {Muthukrishna}, D. and
+	{Narayan}, G. and {Peiris}, H. and {Peters}, C.~M. and {Ponder}, K. and
+	{Setzer}, C.~N. and {The LSST Dark Energy Science Collaboration} and
+	{LSST Transients}, T. and {Variable Stars Science Collaboration}
+	},
+    title = "{The Photometric LSST Astronomical Time-series Classification Challenge (PLAsTiCC): Data set}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1810.00001},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2018,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv181000001T},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{Malz1809.11145,
+   author = {{Malz}, A. and {Hlo{\v z}ek}, R. and {Allam}, Jr, T. and {Bahmanyar}, A. and
+	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Ishida}, E. and
+	{Jha}, S. and {Jones}, D. and {Kessler}, R. and {Lochner}, M. and
+	{Mahabal}, A. and {Mandel}, K. and {Mart{\'{\i}}nez-Galarza}, R. and
+	{McEwen}, J. and {Muthukrishna}, D. and {Narayan}, G. and {Peiris}, H. and
+	{Peters}, C. and {Setzer}, C. and {The LSST Dark Energy Science Collaboration} and
+	{LSST Transients}, T. and {Variable Stars Science Collaboration}
+	},
+    title = "{The Photometric LSST Astronomical Time-series Classification Challenge (PLAsTiCC): Selection of a performance metric for classification probabilities balancing diverse science goals}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1809.11145},
+ primaryClass = "astro-ph.IM",
+ keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
+     year = 2018,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180911145M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{Yao1809.07273,
+   author = {{Yao}, J. and {Ishak}, M. and {Troxel}, M.~A.},
+    title = "{Self-calibration method for II and GI types of intrinsic alignments of galaxies}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1809.07273},
+ keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
+     year = 2018,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180907273Y},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{v1DESC-SRD,
+   author = {{LSST DESC} and {Mandelbaum}, R. and
+	{Eifler}, T. and {Hlo{\v z}ek}, R. and {Collett}, T. and {Gawiser}, E. and
+	{Scolnic}, D. and {Alonso}, D. and {Awan}, H. and {Biswas}, R. and
+	{Blazek}, J. and {Burchat}, P. and {Chisari}, N.~E. and {Dell'Antonio}, I. and
+	{Digel}, S. and {Frieman}, J. and {Goldstein}, D.~A. and {Hook}, I. and
+	{Ivezi{\'c}}, {\v Z}. and {Kahn}, S.~M. and {Kamath}, S. and
+	{Kirkby}, D. and {Kitching}, T. and {Krause}, E. and {Leget}, P.-F. and
+	{Marshall}, P.~J. and {Meyers}, J. and {Miyatake}, H. and {Newman}, J.~A. and
+	{Nichol}, R. and {Rykoff}, E. and {Sanchez}, F.~J. and {Slosar}, A. and
+	{Sullivan}, M. and {Troxel}, M.~A.},
+    title = "{The LSST DESC Science Requirements Document v1}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1809.01669v1},
+ keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+     year = 2018,
+    month = sep,
+   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180901669T},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{Malz1806.00014,
+   author = {{Malz}, A.~I. and {Marshall}, P.~J. and {DeRose}, J. and {Graham}, M.~L. and
+	{Schmidt}, S.~J. and {Wechsler}, R. and {(LSST Dark Energy Science Collaboration}
+	},
+    title = "{Approximating Photo-z PDFs for Large Surveys}",
+  journal = {\aj},
+archivePrefix = "arXiv",
+   eprint = {1806.00014},
+ primaryClass = "astro-ph.IM",
+ keywords = {astronomical databases: miscellaneous, catalogs, galaxies: distances and redshifts, methods: miscellaneous, methods: statistical },
+     year = 2018,
+    month = jul,
+   volume = 156,
+      eid = {35},
+    pages = {35},
+      doi = {10.3847/1538-3881/aac6b5},
+   adsurl = {http://adsabs.harvard.edu/abs/2018AJ....156...35M},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
+
+@ARTICLE{Leonard1802.08263,
+   author = {{Leonard}, C.~D. and {Mandelbaum}, R.},
+    title = "{Measuring the scale-dependence of intrinsic alignments using multiple shear estimates}",
+  journal = {ArXiv e-prints},
+archivePrefix = "arXiv",
+   eprint = {1802.08263},
+ keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
+     year = 2018,
+    month = feb,
+   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180208263L},
+  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
+}
+
 
 @ARTICLE{Mao1709.09665,
    author = {{Mao}, Y.-Y. and {Kovacs}, E. and {Heitmann}, K. and {Uram}, T.~D. and
@@ -29,75 +147,6 @@ archivePrefix = "arXiv",
   adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
 
-@ARTICLE{Leonard1802.08263,
-   author = {{Leonard}, C.~D. and {Mandelbaum}, R.},
-    title = "{Measuring the scale-dependence of intrinsic alignments using multiple shear estimates}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1802.08263},
- keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-     year = 2018,
-    month = feb,
-   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180208263L},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Malz1806.00014,
-   author = {{Malz}, A.~I. and {Marshall}, P.~J. and {DeRose}, J. and {Graham}, M.~L. and
-	{Schmidt}, S.~J. and {Wechsler}, R. and {(LSST Dark Energy Science Collaboration}
-	},
-    title = "{Approximating Photo-z PDFs for Large Surveys}",
-  journal = {\aj},
-archivePrefix = "arXiv",
-   eprint = {1806.00014},
- primaryClass = "astro-ph.IM",
- keywords = {astronomical databases: miscellaneous, catalogs, galaxies: distances and redshifts, methods: miscellaneous, methods: statistical },
-     year = 2018,
-    month = jul,
-   volume = 156,
-      eid = {35},
-    pages = {35},
-      doi = {10.3847/1538-3881/aac6b5},
-   adsurl = {http://adsabs.harvard.edu/abs/2018AJ....156...35M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Yao1809.07273,
-   author = {{Yao}, J. and {Ishak}, M. and {Troxel}, M.~A.},
-    title = "{Self-calibration method for II and GI types of intrinsic alignments of galaxies}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1809.07273},
- keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Astrophysics of Galaxies},
-     year = 2018,
-    month = sep,
-   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180907273Y},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{Malz1809.11145,
-   author = {{Malz}, A. and {Hlo{\v z}ek}, R. and {Allam}, Jr, T. and {Bahmanyar}, A. and
-	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Ishida}, E. and
-	{Jha}, S. and {Jones}, D. and {Kessler}, R. and {Lochner}, M. and
-	{Mahabal}, A. and {Mandel}, K. and {Mart{\'{\i}}nez-Galarza}, R. and
-	{McEwen}, J. and {Muthukrishna}, D. and {Narayan}, G. and {Peiris}, H. and
-	{Peters}, C. and {Setzer}, C. and {The LSST Dark Energy Science Collaboration} and
-	{LSST Transients}, T. and {Variable Stars Science Collaboration}
-	},
-    title = "{The Photometric LSST Astronomical Time-series Classification Challenge (PLAsTiCC): Selection of a performance metric for classification probabilities balancing diverse science goals}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1809.11145},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Cosmology and Nongalactic Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
-     year = 2018,
-    month = sep,
-   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180911145M},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-
-% LSST DESC notes and white papers:
 
 @ARTICLE{WhitePaper,
    author = {{LSST Dark Energy Science Collaboration}},
@@ -112,48 +161,4 @@ archivePrefix = "arXiv",
    adsurl = {http://adsabs.harvard.edu/abs/2012arXiv1211.0310L},
   adsnote = {Provided by the SAO/NASA Astrophysics Data System},
 collaboration = {LSST Dark Energy Science}
-}
-
-@ARTICLE{v1DESC-SRD,
-   author = {{LSST DESC} and {Mandelbaum}, R. and
-	{Eifler}, T. and {Hlo{\v z}ek}, R. and {Collett}, T. and {Gawiser}, E. and
-	{Scolnic}, D. and {Alonso}, D. and {Awan}, H. and {Biswas}, R. and
-	{Blazek}, J. and {Burchat}, P. and {Chisari}, N.~E. and {Dell'Antonio}, I. and
-	{Digel}, S. and {Frieman}, J. and {Goldstein}, D.~A. and {Hook}, I. and
-	{Ivezi{\'c}}, {\v Z}. and {Kahn}, S.~M. and {Kamath}, S. and
-	{Kirkby}, D. and {Kitching}, T. and {Krause}, E. and {Leget}, P.-F. and
-	{Marshall}, P.~J. and {Meyers}, J. and {Miyatake}, H. and {Newman}, J.~A. and
-	{Nichol}, R. and {Rykoff}, E. and {Sanchez}, F.~J. and {Slosar}, A. and
-	{Sullivan}, M. and {Troxel}, M.~A.},
-    title = "{The LSST DESC Science Requirements Document v1}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1809.01669v1},
- keywords = {Astrophysics - Cosmology and Nongalactic Astrophysics},
-     year = 2018,
-    month = sep,
-   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv180901669T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
-}
-
-@ARTICLE{PLAsTiCC1810.00001,
-   author = {{The PLAsTiCC team} and {Allam}, Jr., T. and {Bahmanyar}, A. and
-	{Biswas}, R. and {Dai}, M. and {Galbany}, L. and {Hlo{\v z}ek}, R. and
-	{Ishida}, E.~E.~O. and {Jha}, S.~W. and {Jones}, D.~O. and {Kessler}, R. and
-	{Lochner}, M. and {Mahabal}, A.~A. and {Malz}, A.~I. and {Mandel}, K.~S. and
-	{Mart{\'{\i}}nez-Galarza}, J.~R. and {McEwen}, J.~D. and {Muthukrishna}, D. and
-	{Narayan}, G. and {Peiris}, H. and {Peters}, C.~M. and {Ponder}, K. and
-	{Setzer}, C.~N. and {The LSST Dark Energy Science Collaboration} and
-	{LSST Transients}, T. and {Variable Stars Science Collaboration}
-	},
-    title = "{The Photometric LSST Astronomical Time-series Classification Challenge (PLAsTiCC): Data set}",
-  journal = {ArXiv e-prints},
-archivePrefix = "arXiv",
-   eprint = {1810.00001},
- primaryClass = "astro-ph.IM",
- keywords = {Astrophysics - Instrumentation and Methods for Astrophysics, Astrophysics - Solar and Stellar Astrophysics},
-     year = 2018,
-    month = sep,
-   adsurl = {http://adsabs.harvard.edu/abs/2018arXiv181000001T},
-  adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+bibtexparser

--- a/test/Makefile
+++ b/test/Makefile
@@ -7,8 +7,8 @@ AUX := $(foreach b,$(BSTS),$(b).aux) # $(ROOT).aux
 BBL := $(foreach b,$(BSTS),$(b).bbl) # $(ROOT).bbl
 BLG := $(foreach b,$(BSTS),$(b).blg) # $(ROOT).blg
 PDF := $(ROOT).pdf
-NOTES := $(foreach b,$(BSTS),$(b)Notes.bib) # $(ROOT)Notes.bib 
-ROOTNOTES := $(ROOT)Notes.bib 
+NOTES := $(foreach b,$(BSTS),$(b)Notes.bib) # $(ROOT)Notes.bib
+ROOTNOTES := $(ROOT)Notes.bib
 JUNK := $(BLG) $(ROOT).aux $(ROOT).log $(NOTES) $(ROOTNOTES)
 
 BIB := ../bib/lsstdesc.bib
@@ -34,3 +34,6 @@ $(AUX) $(ROOTNOTES): $(TEX)
 
 $(PDF): $(TEX) $(BBL)
 	pdflatex $(TEX)
+
+html:
+	python make_publication_list.py

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,36 @@
+export TEXINPUTS := ../styles/:../logos/:
+
+ROOT := bibtest
+BSTS := apj mnras
+TEX := $(ROOT).tex
+AUX := $(foreach b,$(BSTS),$(b).aux) # $(ROOT).aux
+BBL := $(foreach b,$(BSTS),$(b).bbl) # $(ROOT).bbl
+BLG := $(foreach b,$(BSTS),$(b).blg) # $(ROOT).blg
+PDF := $(ROOT).pdf
+NOTES := $(foreach b,$(BSTS),$(b)Notes.bib) # $(ROOT)Notes.bib 
+ROOTNOTES := $(ROOT)Notes.bib 
+JUNK := $(BLG) $(ROOT).aux $(ROOT).log $(NOTES) $(ROOTNOTES)
+
+BIB := ../bib/lsstdesc.bib
+
+.PHONY: default tidy clean
+
+default: $(PDF)
+
+tidy:
+	rm -f $(JUNK) $(AUX) $(BBL)
+
+clean: tidy
+	rm -f $(PDF)
+
+$(AUX) $(ROOTNOTES): $(TEX)
+	pdflatex $(TEX)
+
+%.bbl: %.aux $(BIB) $(NOTES)
+	bibtex $<
+
+%Notes.bib: $(ROOTNOTES)
+	cp -f $< $@
+
+$(PDF): $(TEX) $(BBL)
+	pdflatex $(TEX)

--- a/test/bibtest.tex
+++ b/test/bibtest.tex
@@ -1,0 +1,18 @@
+\documentclass[modern]{lsstdescnote}
+
+\usepackage{multibib}
+\newcites{apj,mnras}{ApJ,MNRAS}
+
+\begin{document}
+
+\section*{\tt apj.bst}
+\nociteapj{*}
+\bibliographystyleapj{../bst/apj}
+\bibliographyapj{../bib/lsstdesc}
+
+\section*{\tt mnras.bst}
+\nocitemnras{*}
+\bibliographystylemnras{../bst/mnras}
+\bibliographymnras{../bib/lsstdesc}
+
+\end{document}

--- a/test/make_publication_list.py
+++ b/test/make_publication_list.py
@@ -1,0 +1,69 @@
+"""
+Parse the LSST DESC bibtex file and write out the publication list as an html snippet, for inclusion on the public website.
+"""
+
+from __future__ import print_function
+import bibtexparser
+
+# ======================================================================
+
+def lookup_journal(tex):
+    """
+    Return the name or acronym of the journal, given its tex macro.
+    """
+    plaintext = tex.replace('\\','')
+    lookup = {'apj':'ApJ', 'apjs':'ApJS', 'aj':'AJ', 'mnras':'MNRAS', 'nature':'Nature', 'aap':'A&amp;A', 'pasp':'PASP', 'jcap':'JCAP'}
+    try:
+        journal = lookup[plaintext]
+    except:
+        journal = plaintext
+    return journal
+
+# ----------------------------------------------------------------------
+
+def html_for(entry):
+    """
+    Return a single line of HTML displaying the bibtex entry provided, either to stdout or a file provided.
+    """
+    # First make the authorlist:
+    names = entry['author'].replace('\n',' ').replace('{','').replace('}','').replace('~',' ').replace('\\','').replace("'",'').split(' and ')
+    separator = ', '
+    authorlist = separator.join(names)
+
+    # Clean up the title:
+    title = entry['title'].replace('{','').replace('}','')
+
+    # Now get the journal details:
+    journal = lookup_journal(entry['journal'])
+    try:
+        details = separator.join(['('+entry['year']+')', journal, entry['volume'], entry['pages']])+'.'
+    except:
+        details = separator.join(['('+entry['year']+')', journal])+'.'
+
+    # And now the URLs:
+    ADSurl = entry['adsurl']
+    PDFurl = "https://arxiv.org/pdf/"+entry['eprint']
+    bibcode = ADSurl.split('/')[-1]
+    BIBurl = "http://adsabs.harvard.edu/cgi-bin/nph-bib_query?bibcode="+bibcode+"&amp;data_type=BIBTEX&amp;db_key=AST&amp;nocookieset=1"
+
+    # Compose the single line string:
+    line = '<li style="margin-bottom: 10px;">'+authorlist+' <em>"'+title+'"</em> '+details
+    line += ' (<a href="'+ADSurl+'">ADS</a>, <a href="'+PDFurl+'">PDF</a>, <a href="'+BIBurl+'">bibtex</a>)'+'</li>'
+
+    return line
+
+
+# ======================================================================
+
+if __name__ == '__main__':
+
+    with open('../bib/lsstdesc.bib') as bibtex_file:
+        db = bibtexparser.bparser.BibTexParser(common_strings=True).parse_file(bibtex_file)
+
+    # Loop over the list of bibtex entries:
+    print()
+    for entry in db.entries:
+        print(html_for(entry))
+        print()
+
+# ======================================================================


### PR DESCRIPTION
@abmantz @sethdigel I scraped the DESC paper tracking page for submitted papers and posted notes, and extended the `lsstdesc.bib` file. I also removed the non-DESC publications that were in there, to avoid clashes with the LSST Project bibliography (this closes #24 ). I have not tested this bib file yet, but will see what I can do, there. We need a way of semi-automatically generating the public website html so that it matches this bibliography, so I may try and do something simple in this direction and test the file in the process. For now, great if you can let me know of (or add directly) any more DESC papers beyond the ones I just added.