### PR TITLE
lsstdesc_macros test/demo & cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,3 @@ install:
 # command to run tests
 script:
   - make -C test
-  - make -C test html

--- a/README.md
+++ b/README.md
@@ -18,24 +18,25 @@ Below:
 * [`bst/`](bst/) contains bibliography styles for common journals
 * [`logos/`](logos/) contains graphics used in the DESC Note class
 * [`styles/`](styles/) contains class and style files for common journals, the DESC Note class, and useful macros in `lsstdesc_macros.sty`
+* [`test/`](test/) tests of the bibliography and macros
 
 ## Using DESC macros (`lsstdesc_macros.sty`)
 
 `\usepackage{desc-tex/styles/lsstdesc_macros}`
 
-**TODO**: more documentation
+One of the [tests](test/) produces a PDF showing how the macros compile. This may be useful.
 
 ## Using the DESC standard acknowledgements
 
 E.g. `\input{desc-tex/ack/standard}`. Note that these files contain only the "standard wording" part of the acknowledgements; specific acknowledements for funding agencies, software, etc. associated with a given paper should still be included (see [`ack/README.md`](ack/)).
 
-## Using the DESC Note class
+## Using the DESC Note and other classes
 
-See the example in the [styles README](styles/).
+Via `\documentclass`. For Notes, see the example in the [styles README](styles/). In general, be aware that these classes may rely on other LaTeX packages/infrastructure that is not included with `desc-tex`.
 
 ## Using the DESC bibliography
 
-`\bibliography{desc-tex/bib/lsstdesc,<other .bib file(s)>}`
+`\bibliography{desc-tex/bib/lsstdesc[,other .bib file(s)]}`
 
 Note that, currently, we plan on including only DESC papers in `lsstdesc.bib`.
 
@@ -57,7 +58,7 @@ If you used the `--recursive` flag when cloning, everything will be set up. Othe
 
 ### Getting `desc-tex` without using Git
 
-Standalone deployment of `desc-tex` is possible by clicking the "Clone or download" button at the top right of this page and selecting "Download ZIP". This can also be automated deployment using the [`deploy_from_github_zip.bash`](LSSTDESC/start_paper/blob/master/deploy_from_github_zip.bash) script, as in
+Standalone deployment of `desc-tex` is possible by clicking the "Clone or download" button at the top right of this page and selecting "Download ZIP". This can also be automated deployment using the [`deploy_from_github_zip.bash`](https://github.com/LSSTDESC/start_paper/blob/master/deploy_from_github_zip.bash) script, as in
 ```
 bash ./deploy_from_github_zip.bash desc-tex LSSTDESC/desc-tex master
 ```

--- a/styles/lsstdesc_macros.sty
+++ b/styles/lsstdesc_macros.sty
@@ -7,6 +7,7 @@
 \usepackage{amsmath}
 \usepackage{xspace}
 \usepackage{xcolor}
+\usepackage{accents} % needed for doublehat
 
 % General formatting
 \newcommand{\ie}{i.e.\xspace}
@@ -19,26 +20,23 @@
 
 % Inline comments and highlighting
 \newcommand{\FIXME}[1]{{\bf \textcolor{red}{#1}}}
-%\newcommand{\FIXME}[1]{{#1}}
 \newcommand{\CHECK}[1]{{\bf \textcolor{orange}{#1}}}
-%\newcommand{\CHECK}[1]{{#1}}
 \newcommand{\COMMENT}[1]{{\it \textcolor{blue}{#1}}}
-%\newcommand{\COMMENT}[1]{{#1}}
 \newcommand{\NEW}[1]{{\textcolor{blue}{#1}}}
-%\newcommand{\NEW}[1]{{#1}}
 
 % Math
 \mathchardef\mhyphen="2D
-\newcommand{\vect}[1]{\boldsymbol{#1}}
+\newcommand{\vect}[1]{\ensuremath{\boldsymbol{#1}}}
 \newcommand{\roughly}{\ensuremath{ {\sim}\,} }
 \newcommand{\gtr}{\ensuremath{ {>}\,} }
 \newcommand{\less}{\ensuremath{ {<}\,} }
 \newlength{\dhatheight}
 \newcommand{\doublehat}[1]{%
     \settoheight{\dhatheight}{\ensuremath{\hat{#1}}}%
-    \addtolength{\dhatheight}{-0.35ex}%
-    \hat{\vphantom{\rule{1pt}{\dhatheight}}%
-    \smash{\hat{#1}}}}
+    \addtolength{\dhatheight}{-0.15ex}%
+    \ensuremath{\hat{\vphantom{\rule{1pt}{\dhatheight}}%
+    \smash{\ensuremath{\hat{#1}}}}}
+}
 \newcommand{\code}[1]{\texttt{#1}\xspace}
 \newcommand{\dd}{\ensuremath{\rm d}}
 \newcommand{\var}[1]{\ensuremath{#1}\xspace}
@@ -66,7 +64,7 @@
 \newcommand{\amin}{\unit{arcmin}}
 \newcommand{\asec}{\unit{arcsec}}
 \newcommand{\angstrom}{\unit{\AA}}
-\newcommand{\um}{\unit{$\mu$m}}
+\newcommand{\um}{\unit{\mu m}}
 \newcommand{\cm}{\unit{cm}}
 \newcommand{\km}{\unit{km}}
 \newcommand{\pc}{\unit{pc}}
@@ -74,23 +72,23 @@
 \newcommand{\Mpc}{\unit{Mpc}}
 \newcommand{\Gpc}{\unit{Gpc}}
 \newcommand{\second}{\unit{s}}
-\newcommand{\us}{\unit{$\mu$s}}
+\newcommand{\us}{\unit{\mu s}}
 \newcommand{\photons}{\unit{ph}}
 \newcommand{\photon}{\unit{ph}}
 \newcommand{\sr}{\unit{sr}}
-\newcommand{\Msolar}{\ensuremath{M_\odot}}
-\newcommand{\Msun}{\ensuremath{M_\odot}}
-\newcommand{\Mstar}{\ensuremath{M_{*}}}
-\newcommand{\Lsolar}{\ensuremath{L_\odot}}
-\newcommand{\Lsun}{\ensuremath{L_\odot}}
-\newcommand{\Lstar}{\ensuremath{L_{*}}}
+\newcommand{\Msolar}{\ensuremath{M_\odot}\xspace}
+\newcommand{\Msun}{\ensuremath{M_\odot}\xspace}
+\newcommand{\Mstar}{\ensuremath{M_{*}}\xspace}
+\newcommand{\Lsolar}{\ensuremath{L_\odot}\xspace}
+\newcommand{\Lsun}{\ensuremath{L_\odot}\xspace}
+\newcommand{\Lstar}{\ensuremath{L_{*}}\xspace}
 \newcommand{\Lum}{\ensuremath{ L }\xspace}
-\newcommand{\cmcubes}{\ensuremath{\cm^{3}\second^{-1}}\xspace}
+\newcommand{\cmcubes}{\ensuremath{\cm^{3}\second^{-1}}}
 \newcommand{\magn}{\unit{mag}}
 \newcommand{\mmag}{\unit{mmag}}
 \providecommand{\deg}{}
 \renewcommand{\deg}{\unit{deg}}
-\newcommand{\kms}{{\km\second^{-1}}}
+\newcommand{\kms}{\ensuremath{\km\second^{-1}}}
 
 % Astronomy
 \newcommand{\LCDM}{\ensuremath{\rm \Lambda CDM}\xspace}

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,5 +1,7 @@
 export TEXINPUTS := ../styles/:../logos/:
 
+# for bibliography tests
+BIB := ../bib/lsstdesc.bib
 ROOT := bibtest
 BSTS := apj mnras
 TEX := $(ROOT).tex
@@ -10,18 +12,33 @@ PDF := $(ROOT).pdf
 NOTES := $(foreach b,$(BSTS),$(b)Notes.bib) # $(ROOT)Notes.bib
 ROOTNOTES := $(ROOT)Notes.bib
 JUNK := $(BLG) $(ROOT).aux $(ROOT).log $(NOTES) $(ROOTNOTES)
+HTML := $(ROOT).html
 
-BIB := ../bib/lsstdesc.bib
+# for macro tests
+MACROS := ../styles/lsstdesc_macros.sty
+MACROROOT := macro_demo
+MACROTEX := $(MACROROOT).tex
+MACROPDF := $(MACROROOT).pdf
+JUNK += $(MACROROOT).aux $(MACROROOT).log $(MACROTEX)
 
-.PHONY: default tidy clean
 
-default: $(PDF)
+
+.PHONY: default tidy clean bibtest macrotest
+
+default: bibtest macros
+
+bibtest: $(PDF) $(HTML)
+
+macrotest: $(MACROPDF)
 
 tidy:
 	rm -f $(JUNK) $(AUX) $(BBL)
 
 clean: tidy
-	rm -f $(PDF)
+	rm -f $(PDF) $(HTML) $(MACROPDF)
+
+
+# bibliography tests
 
 $(AUX) $(ROOTNOTES): $(TEX)
 	pdflatex $(TEX)
@@ -35,5 +52,16 @@ $(AUX) $(ROOTNOTES): $(TEX)
 $(PDF): $(TEX) $(BBL)
 	pdflatex $(TEX)
 
-html:
-	python make_publication_list.py
+$(HTML): $(BIB)
+	pip list 2>/dev/null | grep -q bibtexparser || pip install --upgrade-strategy only-if-needed bibtexparser
+	python make_publication_list.py > $@
+
+
+# macros test
+
+$(MACROTEX): $(MACROS)
+	awk -f make_macro_demo.awk $< > $@
+
+$(MACROPDF): $(MACROTEX)
+	pdflatex $<
+

--- a/test/Makefile
+++ b/test/Makefile
@@ -25,7 +25,7 @@ JUNK += $(MACROROOT).aux $(MACROROOT).log $(MACROTEX)
 
 .PHONY: default tidy clean bibtest macrotest
 
-default: bibtest macros
+default: bibtest macrotest
 
 bibtest: $(PDF) $(HTML)
 
@@ -53,7 +53,7 @@ $(PDF): $(TEX) $(BBL)
 	pdflatex $(TEX)
 
 $(HTML): $(BIB)
-	pip list 2>/dev/null | grep -q bibtexparser || pip install --upgrade-strategy only-if-needed bibtexparser
+	#pip list 2>/dev/null | grep -q bibtexparser || pip install --upgrade-strategy only-if-needed bibtexparser
 	python make_publication_list.py > $@
 
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -60,7 +60,7 @@ $(HTML): $(BIB)
 # macros test
 
 $(MACROTEX): $(MACROS)
-	awk -f make_macro_demo.awk $< > $@
+	gawk -f make_macro_demo.awk $< > $@
 
 $(MACROPDF): $(MACROTEX)
 	pdflatex $<

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,21 @@
+Files to test out compilation of the DESC bibliography in various styles, and the DESC macros.
+
+### Requirements
+
+* All prerequisites for the Note class and the included bibliography styles for the PDF bibliography
+* Python packages listed in [../requirements.txt](../requirements.txt) for the HTML bibliography
+* All LaTeX packages included by `lsstdec_macros.sty`
+* `gawk` for the macros demo
+
+### Outputs
+
+* `bibtest.pdf`: document in the DESC Note class that includes the DESC bibliography formatted in each of the available styles.
+* `bibtest.html`: document listing the bibliography in the format used for the public DESC webpage
+* `macro_demo.pdf`: document showing the invocation and output of macros defined in `lsstdesc_macros.sty`
+
+Each of these is a possible target of the `Makefile`, in addition to:
+* `default: bibtest macrotest`
+* `bibtest: bibtest.pdf bibtest.html`
+* `macrotest: macro_demo.pdf`
+* `tidy:` remove temporary files
+* `clean: tidy` and remove output files

--- a/test/make_macro_demo.awk
+++ b/test/make_macro_demo.awk
@@ -1,0 +1,40 @@
+BEGIN {
+    print "\\documentclass{article}"
+    print "\\usepackage{../styles/lsstdesc_macros}"
+    print "\\begin{document}"
+    print "\\section*{{\\tt lsstdesc\\_macros.sty} demo}"
+    print "\\begin{tabular}{|l|l|}"
+    print "\\hline"
+    split("x y z a b c", alph)
+}
+
+{
+    y = match($0, /\\newcommand{(\\[a-zA-Z]+)}(\[)*([0-9]*)(\])*/, a)
+    if (y!=0) {
+	++n
+	if (n % 45 == 0) {
+	    print "\\hline"
+	    print "\\end{tabular}"
+	    print ""
+	    print "\\begin{tabular}{|l|l|}"
+	    print "\\hline"
+	}
+	com = a[1]
+	#if ($0 ~ /\unit/) com = "7" com
+	opts = ""
+	nopts = a[3]
+	if (nopts != "") {
+	    gsub(/[\[\]]/, "", nopts)
+	    for (i=1; i<=nopts; ++i) opts = opts "{" alph[i] "}"
+	}
+	#if ($0 ~ /\\xspace/ || $0 ~ /\unit/) opts = opts " word"
+	print "\\verb|" com opts "|", "&", com opts, "\\\\"
+    }
+}
+
+END {
+    print "\\hline"
+    print "\\end{tabular}"
+    print ""
+    print "\\end{document}"
+}


### PR DESCRIPTION
1. Implements a test that shows what each of our latex macros compiles to
2. Fixes(?) a couple of macros that caused problems
3. Cleans up the HTML bibliography part of the test Makefile