### PR TITLE
Added carriage returns to standard acknowledgments

### DIFF
--- a/ack/key.tex
+++ b/ack/key.tex
@@ -1,1 +1,13 @@
-The DESC acknowledges ongoing support from the Institut National de Physique Nucl\'eaire et de Physique des Particules in France; the Science \& Technology Facilities Council in the United Kingdom; and the Department of Energy, the National Science Foundation, and the LSST Corporation in the United States.  DESC uses resources of the IN2P3 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la Recherche Scientifique; the National Energy Research Scientific Computing Center, a DOE Office of Science User Facility supported by the Office of Science of the U.S.\ Department of Energy under Contract No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BIS National E-infrastructure capital grants; and the UK particle physics grid, supported by the GridPP Collaboration.  This work was performed in part under DOE Contract DE-AC02-76SF00515.
+The DESC acknowledges ongoing support from the Institut National de 
+Physique Nucl\'eaire et de Physique des Particules in France; the 
+Science \& Technology Facilities Council in the United Kingdom; and the 
+Department of Energy, the National Science Foundation, and the LSST 
+Corporation in the United States.  DESC uses resources of the IN2P3 
+Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the 
+Centre National de la Recherche Scientifique; the National Energy 
+Research Scientific Computing Center, a DOE Office of Science User 
+Facility supported by the Office of Science of the U.S.\ Department of
+Energy under Contract No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, 
+funded by UK BIS National E-infrastructure capital grants; and the UK 
+particle physics grid, supported by the GridPP Collaboration.  This 
+work was performed in part under DOE Contract DE-AC02-76SF00515.

--- a/ack/standard.tex
+++ b/ack/standard.tex
@@ -1,1 +1,13 @@
-The DESC acknowledges ongoing support from the Institut National de Physique Nucl\'eaire et de Physique des Particules in France; the Science \& Technology Facilities Council in the United Kingdom; and the Department of Energy, the National Science Foundation, and the LSST Corporation in the United States.  DESC uses resources of the IN2P3 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la Recherche Scientifique; the National Energy Research Scientific Computing Center, a DOE Office of Science User Facility supported by the Office of Science of the U.S.\ Department of Energy under Contract No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BIS National E-infrastructure capital grants; and the UK particle physics grid, supported by the GridPP Collaboration.  This work was performed in part under DOE Contract DE-AC02-76SF00515.
+The DESC acknowledges ongoing support from the Institut National de 
+Physique Nucl\'eaire et de Physique des Particules in France; the 
+Science \& Technology Facilities Council in the United Kingdom; and the
+Department of Energy, the National Science Foundation, and the LSST 
+Corporation in the United States.  DESC uses resources of the IN2P3 
+Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the 
+Centre National de la Recherche Scientifique; the National Energy 
+Research Scientific Computing Center, a DOE Office of Science User 
+Facility supported by the Office of Science of the U.S.\ Department of
+Energy under Contract No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, 
+funded by UK BIS National E-infrastructure capital grants; and the UK 
+particle physics grid, supported by the GridPP Collaboration.  This 
+work was performed in part under DOE Contract DE-AC02-76SF00515.

--- a/ack/standard_short.tex
+++ b/ack/standard_short.tex
@@ -1,1 +1,10 @@
-DESC acknowledges ongoing support from the IN2P3 (France), the STFC (United Kingdom), and the DOE, NSF, and LSST Corporation (United States).  DESC uses resources of the IN2P3 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la Recherche Scientifique; the National Energy Research Scientific Computing Center, a DOE Office of Science User Facility supported under Contract No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BIS National E-infrastructure capital grants; and the UK particle physics grid, supported by the GridPP Collaboration.  This work was performed in part under DOE Contract DE-AC02-76SF00515.
+DESC acknowledges ongoing support from the IN2P3 (France), the STFC 
+(United Kingdom), and the DOE, NSF, and LSST Corporation (United States).  
+DESC uses resources of the IN2P3 Computing Center 
+(CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la
+Recherche Scientifique; the National Energy Research Scientific Computing
+Center, a DOE Office of Science User Facility supported under Contract 
+No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BIS National 
+E-infrastructure capital grants; and the UK particle physics grid, supported
+by the GridPP Collaboration.  This work was performed in part under DOE 
+Contract DE-AC02-76SF00515.


### PR DESCRIPTION
This is to make the acknowledgments easier to browse in GitHub.  No changes of content were made.