### PR TITLE
Updated UK BIS to UK BEIS

### DIFF
--- a/ack/key.tex
+++ b/ack/key.tex
@@ -8,6 +8,6 @@ Centre National de la Recherche Scientifique; the National Energy
 Research Scientific Computing Center, a DOE Office of Science User 
 Facility supported by the Office of Science of the U.S.\ Department of
 Energy under Contract No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, 
-funded by UK BIS National E-infrastructure capital grants; and the UK 
+funded by UK BEIS National E-infrastructure capital grants; and the UK 
 particle physics grid, supported by the GridPP Collaboration.  This 
 work was performed in part under DOE Contract DE-AC02-76SF00515.

--- a/ack/standard.tex
+++ b/ack/standard.tex
@@ -8,6 +8,6 @@ Centre National de la Recherche Scientifique; the National Energy
 Research Scientific Computing Center, a DOE Office of Science User 
 Facility supported by the Office of Science of the U.S.\ Department of
 Energy under Contract No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, 
-funded by UK BIS National E-infrastructure capital grants; and the UK 
+funded by UK BEIS National E-infrastructure capital grants; and the UK 
 particle physics grid, supported by the GridPP Collaboration.  This 
 work was performed in part under DOE Contract DE-AC02-76SF00515.

--- a/ack/standard_short.tex
+++ b/ack/standard_short.tex
@@ -4,7 +4,7 @@ DESC uses resources of the IN2P3 Computing Center
 (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la
 Recherche Scientifique; the National Energy Research Scientific Computing
 Center, a DOE Office of Science User Facility supported under Contract 
-No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BIS National 
+No.\ DE-AC02-05CH11231; STFC DiRAC HPC Facilities, funded by UK BEIS National 
 E-infrastructure capital grants; and the UK particle physics grid, supported
 by the GridPP Collaboration.  This work was performed in part under DOE 
 Contract DE-AC02-76SF00515.


### PR DESCRIPTION
George Madden (STFC representative on the IRC) pointed out that in the DESC standard acknowledgments, 'UK BIS' should now be 'UK BEIS'.