### PR TITLE
Removed LSSTC from the standard acknowledgments

### DIFF
--- a/ack/key.tex
+++ b/ack/key.tex
@@ -1,8 +1,8 @@
 The DESC acknowledges ongoing support from the Institut National de 
 Physique Nucl\'eaire et de Physique des Particules in France; the 
 Science \& Technology Facilities Council in the United Kingdom; and the 
-Department of Energy, the National Science Foundation, and the LSST 
-Corporation in the United States.  DESC uses resources of the IN2P3 
+Department of Energy and National Science Foundation 
+in the United States.  DESC uses resources of the IN2P3 
 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the 
 Centre National de la Recherche Scientifique; the National Energy 
 Research Scientific Computing Center, a DOE Office of Science User 

--- a/ack/standard.tex
+++ b/ack/standard.tex
@@ -1,8 +1,8 @@
 The DESC acknowledges ongoing support from the Institut National de 
 Physique Nucl\'eaire et de Physique des Particules in France; the 
 Science \& Technology Facilities Council in the United Kingdom; and the
-Department of Energy, the National Science Foundation, and the LSST 
-Corporation in the United States.  DESC uses resources of the IN2P3 
+Department of Energy and National Science Foundation 
+in the United States.  DESC uses resources of the IN2P3 
 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the 
 Centre National de la Recherche Scientifique; the National Energy 
 Research Scientific Computing Center, a DOE Office of Science User 

--- a/ack/standard_short.tex
+++ b/ack/standard_short.tex
@@ -1,5 +1,5 @@
 DESC acknowledges ongoing support from the IN2P3 (France), the STFC 
-(United Kingdom), and the DOE, NSF, and LSST Corporation (United States).  
+(United Kingdom), and the DOE and NSF (United States).  
 DESC uses resources of the IN2P3 Computing Center 
 (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la
 Recherche Scientifique; the National Energy Research Scientific Computing


### PR DESCRIPTION
We have not received ongoing support from LSSTC (or its successor LSST Discovery Alliance) for some time.  We may want to consider removing acknowledgment of NSF support, which does not come directly to DESC, but of course is vital to Rubin Observatory.  That can be a separate discussion.