### PR TITLE
Removed NSF and changed LSSTC to LSST DA in standard acknowledgments

### DIFF
--- a/ack/key.tex
+++ b/ack/key.tex
@@ -1,8 +1,8 @@
 The DESC acknowledges ongoing support from the Institut National de 
 Physique Nucl\'eaire et de Physique des Particules in France; the 
 Science \& Technology Facilities Council in the United Kingdom; and the 
-Department of Energy, the National Science Foundation, and the LSST 
-Corporation in the United States.  DESC uses resources of the IN2P3 
+Department of Energy and the LSST Discovery Alliance
+in the United States.  DESC uses resources of the IN2P3 
 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the 
 Centre National de la Recherche Scientifique; the National Energy 
 Research Scientific Computing Center, a DOE Office of Science User 

--- a/ack/standard.tex
+++ b/ack/standard.tex
@@ -1,8 +1,8 @@
 The DESC acknowledges ongoing support from the Institut National de 
 Physique Nucl\'eaire et de Physique des Particules in France; the 
 Science \& Technology Facilities Council in the United Kingdom; and the
-Department of Energy, the National Science Foundation, and the LSST 
-Corporation in the United States.  DESC uses resources of the IN2P3 
+Department of Energy and the LSST Discovery Alliance
+in the United States.  DESC uses resources of the IN2P3 
 Computing Center (CC-IN2P3--Lyon/Villeurbanne - France) funded by the 
 Centre National de la Recherche Scientifique; the National Energy 
 Research Scientific Computing Center, a DOE Office of Science User 

--- a/ack/standard_short.tex
+++ b/ack/standard_short.tex
@@ -1,5 +1,5 @@
 DESC acknowledges ongoing support from the IN2P3 (France), the STFC 
-(United Kingdom), and the DOE, NSF, and LSST Corporation (United States).  
+(United Kingdom), and the DOE and LSST Discovery Alliance (United States).  
 DESC uses resources of the IN2P3 Computing Center 
 (CC-IN2P3--Lyon/Villeurbanne - France) funded by the Centre National de la
 Recherche Scientifique; the National Energy Research Scientific Computing


### PR DESCRIPTION
This change is after discussion with Renee and DESC Management more broadly.  The NSF does not provide direct support to DESC; as always, individual authors with NSF or other agency support should acknowledge that support in DESC papers that they co-author.  This is indicated in the desc-tex acknowledgments README and in the DESC Author Guide.